### PR TITLE
17379: PyPi - Use trusted publishers for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/howso-visuals
+    permissions:
+      id-token: write
 
     steps:
 
@@ -61,5 +62,3 @@ jobs:
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.OFFICIAL_PYPI_API_TOKEN }}


### PR DESCRIPTION
Removed token-based authentication in the release workflow.