### PR TITLE
22866: Downgrades Plotly version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "howso-engine~=35.0",
-    "plotly",
+    "plotly~=5.0",
     "scipy",
     "seaborn",
     "umap-learn~=0.5",


### PR DESCRIPTION
Plotly 6.0 causes a deprecation warning to be raised when making just about any plot, downgrading until this is resolved by the plotly folks.