### PR TITLE
25682: Add @howsoai/agent-devs to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 ##########################################
 
 # default ownership: default owners for everything in the repo (Unless a later match takes precedence)
-* @howsoai/devs
+* @howsoai/devs @howsoai/agent-devs


### PR DESCRIPTION
Adds `@howsoai/agent-devs` as a co-owner so the team's reviews satisfy the required code-owner review. Either `@howsoai/devs` or `@howsoai/agent-devs` approval now gates merge.

Part of agent-devs enablement. Refs AD#25682.